### PR TITLE
csso minify: Turn off restructure

### DIFF
--- a/lib/css-min.js
+++ b/lib/css-min.js
@@ -1,4 +1,4 @@
 module.exports = ( body ) => {
 	const csso = require( 'csso' );
-	return csso.minify( body ).css;
+	return csso.minify( body, { restructure: false } ).css;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "minifiers",
-	"version": "8.1.1",
+	"version": "8.1.2",
 	"description": "HTTP minification proxy for HTML, CSS, JS, and SVG.",
 	"main": "server.js",
 	"engines": {


### PR DESCRIPTION
The csso library for minification has a "restructure" option, which breaks things in some cases. Test example is:

```css
.test {
    font: inherit;
    font-size: 24px;
}

.other {
    color: red;
    font-size: 24px;
}
```

Three documents using it, and screenshots:

(Original)
```html
<!DOCTYPE html>
<html>
<head>
  <style>
    .test {
        font: inherit;
        font-size: 24px;
    }

    .other {
        color: red;
        font-size: 24px;
    }
  </style>
</head>
<body>
    ORIGINAL
  <p class="test">This is a paragraph with the "test" class.</p>
  <p class="other">This is a paragraph with the "other" class.</p>
</body>
</html>
```

(Minified with structuring on, trunk before this PR)
```html
<!DOCTYPE html>
<html>
<head>
  <style>
    .other,.test{font-size:24px}.test{font:inherit}.other{color:red}
  </style>
</head>
<body>
    MINIFIED - TRUNK
  <p class="test">This is a paragraph with the "test" class.</p>
  <p class="other">This is a paragraph with the "other" class.</p>
</body>
</html>
```

(Minified with structuring off, after this PR)
```html
<!DOCTYPE html>
<html>
<head>
  <style>
    .test{font:inherit;font-size:24px}.other{color:red;font-size:24px}
  </style>
</head>
<body>
    MINIFIED - RESTRUCTURE OFF
  <p class="test">This is a paragraph with the "test" class.</p>
  <p class="other">This is a paragraph with the "other" class.</p>
</body>
</html>
```

![2023-05-31_13-14](https://github.com/Automattic/minifiers/assets/937354/890d4c30-c91c-486d-8a3e-d5aab1ad000d)
