### PR TITLE
Node 18 Compatibility and Testing Enhancements

### DIFF
--- a/.github/workflows/requests.yml
+++ b/.github/workflows/requests.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+
     - name: Install Dependencies
       run: npm install
 

--- a/.github/workflows/requests.yml
+++ b/.github/workflows/requests.yml
@@ -1,6 +1,12 @@
 name: Minifiers Requests Tests
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
 
 jobs:
   build-test:

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
 	},
 	"scripts": {
 		"prettify": "prettier --write \"lib/**/*\" \"routes/**/*\" \"tests/**/*.test.js\" \"server.js\" \"config.js\" \"README.md\"",
-		"test": "node --dns-result-order=ipv4first ./node_modules/jest/bin/jest.js --forceExit ./tests"
+		"test": "node --dns-result-order=ipv4first ./node_modules/jest/bin/jest.js ./tests"
 	}
 }

--- a/tests/test-server-utils.js
+++ b/tests/test-server-utils.js
@@ -1,4 +1,4 @@
-const { exec } = require( 'child_process' );
+const { spawn } = require( 'child_process' );
 
 /**
  * Generates a random port number between 3000 and 9000.
@@ -26,11 +26,13 @@ function startServer( env, port = null ) {
 		if ( port === null ) {
 			port = generateRandomPort();
 		}
-		const server = exec(
-			`npm start -- -p ${ port }`,
+		const server = spawn(
+			'node',
+			[ './server.js', `--port=${ port }` ],
 			{ env: { ...process.env, ...env } },
 			( error ) => {
 				if ( error ) {
+					console.error( 'Error starting server', error );
 					reject( error );
 				}
 			}
@@ -39,6 +41,10 @@ function startServer( env, port = null ) {
 			if ( data.includes( 'Server listening' ) ) {
 				resolve( { server, port } );
 			}
+		} );
+
+		server.stderr.on( 'data', ( data ) => {
+			console.info( `stderr: ${ data }` );
 		} );
 	} );
 }


### PR DESCRIPTION
### Node 18 Standardization

- Updated the GitHub Actions workflow to explicitly use Node.js version 18.
- Added an `.nvmrc` file specifying `lts/hydrogen` for consistent Node.js versioning in local development.

### Tests Passing on Node 18; better process management

- Replaced `exec` with `spawn` in `test-server-utils.js`.
  - This removes one level of indirection of pids, allowing tests to pass on PIDs and for the temporary servers spawned during testing to be terminated instead of timed out.
  - Now tests pass on node 18, but they will fail on node 16. (Different signal handling behaviors).
- Modified `package.json` to remove `--forceExit` from the test script.