### PR TITLE
node: update from 18 lts to 20 lts

### DIFF
--- a/.github/workflows/requests.yml
+++ b/.github/workflows/requests.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: Install Dependencies
       run: npm install

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-slim
+FROM node:20-slim
 
 WORKDIR /box/minifiers
 COPY . .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "minifiers",
-	"version": "8.1.3",
+	"version": "8.2.0",
 	"description": "HTTP minification proxy for HTML, CSS, JS, and SVG.",
 	"main": "server.js",
 	"engines": {


### PR DESCRIPTION
https://nodejs.org/en/blog/release/v20.0.0

Seems there's not much to do here.  There's an experimental permission model behind a flag, `new WASI()` now requires a version, and `url.parse()` when given ports that are not numbers is now deprecated. We are not using either of those.

https://endoflife.date/nodejs

![2024-06-24_08-32](https://github.com/Automattic/minifiers/assets/937354/84bde2ba-6a28-4fa0-9ea0-11798db2f09e)
