### PR TITLE
replace html-minifier 4.0.0 with html-minifier-terser 7.2.0

### DIFF
--- a/lib/html-min.js
+++ b/lib/html-min.js
@@ -1,8 +1,8 @@
-module.exports = ( body ) => {
-	const html = require( 'html-minifier' );
+module.exports = async ( body ) => {
+	const html = require( 'html-minifier-terser' );
 	const csso = require( 'csso' );
 
-	const result = html.minify( body, {
+	const result = await html.minify( body, {
 		collapseWhitespace: true,
 		minifyJS: true,
 		minifyCSS: function ( text, type ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"csso": "^5.0.5",
 				"fastify": "^4.28.0",
 				"generic-pool": "^3.9.0",
-				"html-minifier": "^4.0.0",
+				"html-minifier-terser": "^7.2.0",
 				"jsonminify": "^0.4.2",
 				"mime-types": "^2.1.35",
 				"node-getopt": "git://github.com/tuxpoldo/node-getopt.git#05e498731c14b648fa332ca78d3a301c5e4be440",
@@ -1016,14 +1016,14 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-			"dev": true,
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/trace-mapping": "^0.3.24"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -1033,31 +1033,39 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
 			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true,
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+			"integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.20",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
-			"dev": true,
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1415,6 +1423,18 @@
 			"resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
 			"integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
 		},
+		"node_modules/acorn": {
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "8.12.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -1770,8 +1790,7 @@
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.7",
@@ -1801,12 +1820,13 @@
 			}
 		},
 		"node_modules/camel-case": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-			"integrity": "sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+			"license": "MIT",
 			"dependencies": {
-				"no-case": "^2.2.0",
-				"upper-case": "^1.1.1"
+				"pascal-case": "^3.1.2",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/camelcase": {
@@ -1885,14 +1905,15 @@
 			"dev": true
 		},
 		"node_modules/clean-css": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
-			"integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+			"integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+			"license": "MIT",
 			"dependencies": {
 				"source-map": "~0.6.0"
 			},
 			"engines": {
-				"node": ">= 4.0"
+				"node": ">= 10.0"
 			}
 		},
 		"node_modules/cliui": {
@@ -1955,9 +1976,13 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
 		},
 		"node_modules/component-emitter": {
 			"version": "1.3.0",
@@ -2214,6 +2239,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/dot-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+			"license": "MIT",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/electron-to-chromium": {
@@ -2766,14 +2801,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"bin": {
-				"he": "bin/he"
-			}
-		},
 		"node_modules/hexoid": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
@@ -2788,24 +2815,25 @@
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
-		"node_modules/html-minifier": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
-			"integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+		"node_modules/html-minifier-terser": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+			"integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+			"license": "MIT",
 			"dependencies": {
-				"camel-case": "^3.0.0",
-				"clean-css": "^4.2.1",
-				"commander": "^2.19.0",
-				"he": "^1.2.0",
-				"param-case": "^2.1.1",
+				"camel-case": "^4.1.2",
+				"clean-css": "~5.3.2",
+				"commander": "^10.0.0",
+				"entities": "^4.4.0",
+				"param-case": "^3.0.4",
 				"relateurl": "^0.2.7",
-				"uglify-js": "^3.5.1"
+				"terser": "^5.15.1"
 			},
 			"bin": {
-				"html-minifier": "cli.js"
+				"html-minifier-terser": "cli.js"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": "^14.13.1 || >=16.0.0"
 			}
 		},
 		"node_modules/human-signals": {
@@ -3691,9 +3719,13 @@
 			}
 		},
 		"node_modules/lower-case": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-			"integrity": "sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
 		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
@@ -3824,11 +3856,13 @@
 			"dev": true
 		},
 		"node_modules/no-case": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+			"license": "MIT",
 			"dependencies": {
-				"lower-case": "^1.1.1"
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/node-getopt": {
@@ -3978,11 +4012,13 @@
 			}
 		},
 		"node_modules/param-case": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-			"integrity": "sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+			"license": "MIT",
 			"dependencies": {
-				"no-case": "^2.2.0"
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/parse-json": {
@@ -4001,6 +4037,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+			"license": "MIT",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/path-exists": {
@@ -4265,6 +4311,7 @@
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
 			"integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
 			}
@@ -4729,6 +4776,40 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/terser": {
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.32.0.tgz",
+			"integrity": "sha512-v3Gtw3IzpBJ0ugkxEX8U0W6+TnPKRRCWGh1jC/iM/e3Ki5+qvO1L1EAZ56bZasc64aXHwRHNIQEzm6//i5cemQ==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.8.2",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/terser/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"license": "MIT"
+		},
+		"node_modules/terser/node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -4787,6 +4868,12 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/tslib": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+			"license": "0BSD"
+		},
 		"node_modules/type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4806,17 +4893,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/uglify-js": {
-			"version": "3.17.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-			"bin": {
-				"uglifyjs": "bin/uglifyjs"
-			},
-			"engines": {
-				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/undici-types": {
@@ -4854,11 +4930,6 @@
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
 			}
-		},
-		"node_modules/upper-case": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-			"integrity": "sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA=="
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"csso": "^5.0.5",
 		"fastify": "^4.28.0",
 		"generic-pool": "^3.9.0",
-		"html-minifier": "^4.0.0",
+		"html-minifier-terser": "^7.2.0",
 		"jsonminify": "^0.4.2",
 		"mime-types": "^2.1.35",
 		"node-getopt": "git://github.com/tuxpoldo/node-getopt.git#05e498731c14b648fa332ca78d3a301c5e4be440",


### PR DESCRIPTION
html-minifier has [CVE-2022-37620](https://github.com/advisories/GHSA-pfq8-rq6v-vf5m) ([kangax/html-minifier#1135](https://github.com/kangax/html-minifier/issues/1135)) and hasn't been updated in 5 years. There's fork of it maintained by terser: https://www.npmjs.com/package/html-minifier-terser.