### PR TITLE
superagent: upgrade 9.0.2 -> 10.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"jsonminify": "^0.4.2",
 				"mime-types": "^2.1.35",
 				"node-getopt": "git://github.com/tuxpoldo/node-getopt.git#05e498731c14b648fa332ca78d3a301c5e4be440",
-				"superagent": "^9.0.2",
+				"superagent": "^10.1.1",
 				"svgo": "^3.0.2"
 			},
 			"devDependencies": {
@@ -1543,7 +1543,8 @@
 		"node_modules/asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+			"integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+			"license": "MIT"
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -2189,6 +2190,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
 			"integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+			"license": "ISC",
 			"dependencies": {
 				"asap": "^2.0.0",
 				"wrappy": "1"
@@ -2602,12 +2604,13 @@
 			}
 		},
 		"node_modules/formidable": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
-			"integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+			"integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
+			"license": "MIT",
 			"dependencies": {
 				"dezalgo": "^1.0.4",
-				"hexoid": "^1.0.0",
+				"hexoid": "^2.0.0",
 				"once": "^1.4.0"
 			},
 			"funding": {
@@ -2815,9 +2818,10 @@
 			}
 		},
 		"node_modules/hexoid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-			"integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+			"integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -4703,16 +4707,17 @@
 			}
 		},
 		"node_modules/superagent": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
-			"integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-10.1.1.tgz",
+			"integrity": "sha512-9pIwrHrOj3uAnqg9gDlW7EA2xv+N5au/dSM0kM22HTqmUu8jBxNT+8uA7tA3UoCnmiqzpSbu8rasIUZvbyamMQ==",
+			"license": "MIT",
 			"dependencies": {
 				"component-emitter": "^1.3.0",
 				"cookiejar": "^2.1.4",
 				"debug": "^4.3.4",
 				"fast-safe-stringify": "^2.1.1",
 				"form-data": "^4.0.0",
-				"formidable": "^3.5.1",
+				"formidable": "^3.5.2",
 				"methods": "^1.1.2",
 				"mime": "2.6.0",
 				"qs": "^6.11.0"
@@ -4729,6 +4734,27 @@
 			"dependencies": {
 				"methods": "^1.1.2",
 				"superagent": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=14.18.0"
+			}
+		},
+		"node_modules/supertest/node_modules/superagent": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+			"integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"component-emitter": "^1.3.0",
+				"cookiejar": "^2.1.4",
+				"debug": "^4.3.4",
+				"fast-safe-stringify": "^2.1.1",
+				"form-data": "^4.0.0",
+				"formidable": "^3.5.1",
+				"methods": "^1.1.2",
+				"mime": "2.6.0",
+				"qs": "^6.11.0"
 			},
 			"engines": {
 				"node": ">=14.18.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"jsonminify": "^0.4.2",
 		"mime-types": "^2.1.35",
 		"node-getopt": "git://github.com/tuxpoldo/node-getopt.git#05e498731c14b648fa332ca78d3a301c5e4be440",
-		"superagent": "^9.0.2",
+		"superagent": "^10.1.1",
 		"svgo": "^3.0.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Changes made

The major change here is that superagent now supports brotli compression format when making requests. This should be an extra feature we get when using the "get" portion of the minifers without any changes needed on our side. 

https://github.com/ladjs/superagent/commit/5ab6b88e3ba5765cdf7689d8d2238f9267ff355a

## To test

`npm test` or checking that the `get` feature continues to work with URLs like: `http://localhost:4747/get?url=https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.css`