### PR TITLE
fastify: upgrade 4.28.0 -> 5.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@swc/core": "^1.10.4",
 				"csso": "^5.0.5",
-				"fastify": "^5.2.0",
+				"fastify": "^5.2.1",
 				"generic-pool": "^3.9.0",
 				"html-minifier-terser": "^7.2.0",
 				"jsonminify": "^0.4.2",
@@ -717,6 +717,12 @@
 				"fast-json-stringify": "^6.0.0"
 			}
 		},
+		"node_modules/@fastify/forwarded": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.0.tgz",
+			"integrity": "sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA==",
+			"license": "MIT"
+		},
 		"node_modules/@fastify/merge-json-schemas": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
@@ -724,6 +730,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
+			}
+		},
+		"node_modules/@fastify/proxy-addr": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.0.0.tgz",
+			"integrity": "sha512-37qVVA1qZ5sgH7KpHkkC4z9SK6StIsIcOmpjvMPXNb3vx2GQxhZocogVYbr2PbbeLCQxYIPDok307xEvRZOzGA==",
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/forwarded": "^3.0.0",
+				"ipaddr.js": "^2.1.0"
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -2510,9 +2526,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastify": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.2.0.tgz",
-			"integrity": "sha512-3s+Qt5S14Eq5dCpnE0FxTp3z4xKChI83ZnMv+k0FwX+VUoZrgCFoLAxpfdi/vT4y6Mk+g7aAMt9pgXDoZmkefQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.2.1.tgz",
+			"integrity": "sha512-rslrNBF67eg8/Gyn7P2URV8/6pz8kSAscFL4EThZJ8JBMaXacVdVE4hmUcnPNKERl5o/xTiBSLfdowBRhVF1WA==",
 			"funding": [
 				{
 					"type": "github",
@@ -2528,6 +2544,7 @@
 				"@fastify/ajv-compiler": "^4.0.0",
 				"@fastify/error": "^4.0.0",
 				"@fastify/fast-json-stringify-compiler": "^5.0.0",
+				"@fastify/proxy-addr": "^5.0.0",
 				"abstract-logging": "^2.0.1",
 				"avvio": "^9.0.0",
 				"fast-json-stringify": "^6.0.0",
@@ -2535,7 +2552,6 @@
 				"light-my-request": "^6.0.0",
 				"pino": "^9.0.0",
 				"process-warning": "^4.0.0",
-				"proxy-addr": "^2.0.7",
 				"rfdc": "^1.3.1",
 				"secure-json-parse": "^3.0.1",
 				"semver": "^7.6.0",
@@ -2641,14 +2657,6 @@
 			},
 			"funding": {
 				"url": "https://ko-fi.com/tunnckoCore/commissions"
-			}
-		},
-		"node_modules/forwarded": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -2952,11 +2960,12 @@
 			"dev": true
 		},
 		"node_modules/ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+			"integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+			"license": "MIT",
 			"engines": {
-				"node": ">= 0.10"
+				"node": ">= 10"
 			}
 		},
 		"node_modules/is-arrayish": {
@@ -4283,18 +4292,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/proxy-addr": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-			"dependencies": {
-				"forwarded": "0.2.0",
-				"ipaddr.js": "1.9.1"
-			},
-			"engines": {
-				"node": ">= 0.10"
 			}
 		},
 		"node_modules/pure-rand": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@swc/core": "^1.10.4",
 				"csso": "^5.0.5",
-				"fastify": "^4.28.0",
+				"fastify": "^5.2.0",
 				"generic-pool": "^3.9.0",
 				"html-minifier-terser": "^7.2.0",
 				"jsonminify": "^0.4.2",
@@ -682,32 +682,46 @@
 			"dev": true
 		},
 		"node_modules/@fastify/ajv-compiler": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.5.0.tgz",
-			"integrity": "sha512-ebbEtlI7dxXF5ziNdr05mOY8NnDiPB1XvAlLHctRt/Rc+C3LCOVW5imUVX+mhvUhnNzmPBHewUkOFgGlCxgdAA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.2.tgz",
+			"integrity": "sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
-				"ajv": "^8.11.0",
-				"ajv-formats": "^2.1.1",
-				"fast-uri": "^2.0.0"
+				"ajv": "^8.12.0",
+				"ajv-formats": "^3.0.1",
+				"fast-uri": "^3.0.0"
 			}
 		},
 		"node_modules/@fastify/error": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
-			"integrity": "sha512-wWSvph+29GR783IhmvdwWnN4bUxTD01Vm5Xad4i7i1VuAOItLvbPAb69sb0IQ2N57yprvhNIwAP5B6xfKTmjmQ=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.0.0.tgz",
+			"integrity": "sha512-OO/SA8As24JtT1usTUTKgGH7uLvhfwZPwlptRi2Dp5P4KKmJI3gvsZ8MIHnNwDs4sLf/aai5LzTyl66xr7qMxA==",
+			"license": "MIT"
 		},
 		"node_modules/@fastify/fast-json-stringify-compiler": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.3.0.tgz",
-			"integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.1.tgz",
+			"integrity": "sha512-f2d3JExJgFE3UbdFcpPwqNUEoHWmt8pAKf8f+9YuLESdefA0WgqxeT6DrGL4Yrf/9ihXNSKOqpjEmurV405meA==",
+			"license": "MIT",
 			"dependencies": {
-				"fast-json-stringify": "^5.7.0"
+				"fast-json-stringify": "^6.0.0"
 			}
 		},
 		"node_modules/@fastify/merge-json-schemas": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.1.1.tgz",
 			"integrity": "sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==",
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
 			}
@@ -1449,14 +1463,15 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -1464,9 +1479,10 @@
 			}
 		},
 		"node_modules/ajv-formats": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -1560,11 +1576,12 @@
 			}
 		},
 		"node_modules/avvio": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/avvio/-/avvio-8.3.2.tgz",
-			"integrity": "sha512-st8e519GWHa/azv8S87mcJvZs4WsgTBjOw/Ih1CP6u+8SZvcOeAYNG6JbsIrAUUJJ7JfmrnOkR8ipDS+u9SIRQ==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/avvio/-/avvio-9.1.0.tgz",
+			"integrity": "sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==",
+			"license": "MIT",
 			"dependencies": {
-				"@fastify/error": "^3.3.0",
+				"@fastify/error": "^4.0.0",
 				"fastq": "^1.17.1"
 			}
 		},
@@ -2016,11 +2033,12 @@
 			"dev": true
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+			"integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+			"license": "MIT",
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">=18"
 			}
 		},
 		"node_modules/cookiejar": {
@@ -2424,20 +2442,17 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/fast-content-type-parse": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz",
-			"integrity": "sha512-fBHHqSTFLVnR61C+gltJuE5GkVQMV0S2nqUO8TJ+5Z3qAKG8vAx4FKai1s5jq/inV1+sREynIWSuQ6HgoSXpDQ=="
-		},
 		"node_modules/fast-decode-uri-component": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+			"integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
@@ -2446,39 +2461,31 @@
 			"dev": true
 		},
 		"node_modules/fast-json-stringify": {
-			"version": "5.16.1",
-			"resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.16.1.tgz",
-			"integrity": "sha512-KAdnLvy1yu/XrRtP+LJnxbBGrhN+xXu+gt3EUvZhYGKCr3lFHq/7UFJHHFgmJKoqlh6B40bZLEv7w46B0mqn1g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.0.0.tgz",
+			"integrity": "sha512-FGMKZwniMTgZh7zQp9b6XnBVxUmKVahQLQeRQHqwYmPDqDhcEKZ3BaQsxelFFI5PY7nN71OEeiL47/zUWcYe1A==",
+			"license": "MIT",
 			"dependencies": {
-				"@fastify/merge-json-schemas": "^0.1.0",
-				"ajv": "^8.10.0",
+				"@fastify/merge-json-schemas": "^0.1.1",
+				"ajv": "^8.12.0",
 				"ajv-formats": "^3.0.1",
 				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^2.1.0",
+				"fast-uri": "^2.3.0",
 				"json-schema-ref-resolver": "^1.0.1",
 				"rfdc": "^1.2.0"
 			}
 		},
-		"node_modules/fast-json-stringify/node_modules/ajv-formats": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-			"dependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"ajv": {
-					"optional": true
-				}
-			}
+		"node_modules/fast-json-stringify/node_modules/fast-uri": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
+			"integrity": "sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==",
+			"license": "MIT"
 		},
 		"node_modules/fast-querystring": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
 			"integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+			"license": "MIT",
 			"dependencies": {
 				"fast-decode-uri-component": "^1.0.1"
 			}
@@ -2497,14 +2504,15 @@
 			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
 		},
 		"node_modules/fast-uri": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.2.0.tgz",
-			"integrity": "sha512-cIusKBIt/R/oI6z/1nyfe2FvGKVTohVRfvkOhvx0nCEW+xf5NoCXjAHcWp93uOUBchzYcsvPlrapAdX1uW+YGg=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+			"integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastify": {
-			"version": "4.28.0",
-			"resolved": "https://registry.npmjs.org/fastify/-/fastify-4.28.0.tgz",
-			"integrity": "sha512-HhW7UHW07YlqH5qpS0af8d2Gl/o98DhJ8ZDQWHRNDnzeOhZvtreWsX8xanjGgXmkYerGbo8ax/n40Dpwqkot8Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.2.0.tgz",
+			"integrity": "sha512-3s+Qt5S14Eq5dCpnE0FxTp3z4xKChI83ZnMv+k0FwX+VUoZrgCFoLAxpfdi/vT4y6Mk+g7aAMt9pgXDoZmkefQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -2515,29 +2523,46 @@
 					"url": "https://opencollective.com/fastify"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"@fastify/ajv-compiler": "^3.5.0",
-				"@fastify/error": "^3.4.0",
-				"@fastify/fast-json-stringify-compiler": "^4.3.0",
+				"@fastify/ajv-compiler": "^4.0.0",
+				"@fastify/error": "^4.0.0",
+				"@fastify/fast-json-stringify-compiler": "^5.0.0",
 				"abstract-logging": "^2.0.1",
-				"avvio": "^8.3.0",
-				"fast-content-type-parse": "^1.1.0",
-				"fast-json-stringify": "^5.8.0",
-				"find-my-way": "^8.0.0",
-				"light-my-request": "^5.11.0",
+				"avvio": "^9.0.0",
+				"fast-json-stringify": "^6.0.0",
+				"find-my-way": "^9.0.0",
+				"light-my-request": "^6.0.0",
 				"pino": "^9.0.0",
-				"process-warning": "^3.0.0",
+				"process-warning": "^4.0.0",
 				"proxy-addr": "^2.0.7",
-				"rfdc": "^1.3.0",
-				"secure-json-parse": "^2.7.0",
-				"semver": "^7.5.4",
-				"toad-cache": "^3.3.0"
+				"rfdc": "^1.3.1",
+				"secure-json-parse": "^3.0.1",
+				"semver": "^7.6.0",
+				"toad-cache": "^3.7.0"
 			}
 		},
+		"node_modules/fastify/node_modules/process-warning": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+			"integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/fastq": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
+			"integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
 			}
@@ -2565,13 +2590,14 @@
 			}
 		},
 		"node_modules/find-my-way": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.0.tgz",
-			"integrity": "sha512-HdWXgFYc6b1BJcOBDBwjqWuHJj1WYiqrxSh25qtU4DabpMFdj/gSunNBQb83t+8Zt67D7CXEzJWTkxaShMTMOA==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.1.0.tgz",
+			"integrity": "sha512-Y5jIsuYR4BwWDYYQ2A/RWWE6gD8a0FMgtU+HOq1WKku+Cwdz8M1v8wcAmRXXM1/iqtoqg06v+LjAxMYbCjViMw==",
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-querystring": "^1.0.0",
-				"safe-regex2": "^3.1.0"
+				"safe-regex2": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=14"
@@ -3659,6 +3685,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-1.0.1.tgz",
 			"integrity": "sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==",
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
 			}
@@ -3666,7 +3693,8 @@
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",
@@ -3708,14 +3736,31 @@
 			}
 		},
 		"node_modules/light-my-request": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.13.0.tgz",
-			"integrity": "sha512-9IjUN9ZyCS9pTG+KqTDEQo68Sui2lHsYBrfMyVUTTZ3XhH8PMZq7xO94Kr+eP9dhi/kcKsx4N41p2IXEBil1pQ==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.4.0.tgz",
+			"integrity": "sha512-U0UONITz4GVQodMPoygnqJan2RYfhyLsCzFBakJHWNfiQKyHzvp38YOxxLGs8lIDPwR6ngd4gmuZJQQJtRBu/A==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"cookie": "^0.6.0",
-				"process-warning": "^3.0.0",
-				"set-cookie-parser": "^2.4.1"
+				"cookie": "^1.0.1",
+				"process-warning": "^4.0.0",
+				"set-cookie-parser": "^2.6.0"
 			}
+		},
+		"node_modules/light-my-request/node_modules/process-warning": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+			"integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
@@ -4252,14 +4297,6 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/punycode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/pure-rand": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
@@ -4346,6 +4383,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4398,9 +4436,10 @@
 			}
 		},
 		"node_modules/ret": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/ret/-/ret-0.4.3.tgz",
-			"integrity": "sha512-0f4Memo5QP7WQyUEAYUO3esD/XjOc3Zjjg5CPsAq1p8sIu0XPeMbHJemKA0BO7tV0X7+A0FoEpbmHXWxPyD3wQ==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+			"integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -4409,6 +4448,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"license": "MIT",
 			"engines": {
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
@@ -4417,7 +4457,8 @@
 		"node_modules/rfdc": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
+			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+			"license": "MIT"
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -4439,11 +4480,22 @@
 			]
 		},
 		"node_modules/safe-regex2": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-3.1.0.tgz",
-			"integrity": "sha512-RAAZAGbap2kBfbVhvmnTFv73NWLMvDGOITFYTZBAaY8eR+Ir4ef7Up/e7amo+y1+AH+3PtLkrt9mvcTsG9LXug==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-4.0.1.tgz",
+			"integrity": "sha512-goqsB+bSlOmVX+CiFX2PFc1OV88j5jvBqIM+DgqrucHnUguAUNtiNOs+aTadq2NqsLQ+TQ3UEVG3gtSFcdlkCg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT",
 			"dependencies": {
-				"ret": "~0.4.0"
+				"ret": "~0.5.0"
 			}
 		},
 		"node_modules/safe-stable-stringify": {
@@ -4455,17 +4507,26 @@
 			}
 		},
 		"node_modules/secure-json-parse": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-			"integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
+			"integrity": "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -4473,26 +4534,11 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/semver/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/semver/node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-		},
 		"node_modules/set-cookie-parser": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
-			"integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+			"license": "MIT"
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
@@ -4968,14 +5014,6 @@
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
-			}
-		},
-		"node_modules/uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dependencies": {
-				"punycode": "^2.1.0"
 			}
 		},
 		"node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"dependencies": {
 		"@swc/core": "^1.10.4",
 		"csso": "^5.0.5",
-		"fastify": "^4.28.0",
+		"fastify": "^5.2.0",
 		"generic-pool": "^3.9.0",
 		"html-minifier-terser": "^7.2.0",
 		"jsonminify": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"dependencies": {
 		"@swc/core": "^1.10.4",
 		"csso": "^5.0.5",
-		"fastify": "^5.2.0",
+		"fastify": "^5.2.1",
 		"generic-pool": "^3.9.0",
 		"html-minifier-terser": "^7.2.0",
 		"jsonminify": "^0.4.2",


### PR DESCRIPTION
# Upgrade Fastify from v4 to v5

This PR upgrades Fastify to version 5. After reviewing our codebase against the [official migration guide](https://github.com/fastify/fastify/blob/main/docs/Guides/Migration-Guide-V5.md), no code changes were required because:

1. We're already running on Node.js v20 (Fastify v5 requirement)
2. Our codebase doesn't use any deprecated Fastify v4 features:
   - Our route handlers use consistent async/await and promise patterns
   - We don't use any deprecated request/reply properties
   - Our `.listen()` calls already use the new object-based signature
   - We don't use schema validation features that would require updates

3. Our current usage patterns are compatible with v5:
   - Simple logger configuration using boolean values
   - Standard request properties (`request.query`, `request.headers`)
   - Standard reply methods (`reply.code()`, `reply.header()`, `reply.send()`)
   - GET and OPTIONS routes only (no affected DELETE routes)

## Test/Verify

`npm install`, then `npm test` or `npm start` and testing all existing endpoints:
   - `/` (index)
   - `/health-check`
   - `/file`
   - `/get`