### PR TITLE
svgo: upgrade 3.0.2 -> 3.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"mime-types": "^2.1.35",
 				"node-getopt": "git://github.com/tuxpoldo/node-getopt.git#05e498731c14b648fa332ca78d3a301c5e4be440",
 				"superagent": "^10.1.1",
-				"svgo": "^3.0.2"
+				"svgo": "^3.3.2"
 			},
 			"devDependencies": {
 				"jest": "^29.7.0",
@@ -4828,14 +4828,16 @@
 			}
 		},
 		"node_modules/svgo": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-			"integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
+			"integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+			"license": "MIT",
 			"dependencies": {
 				"@trysound/sax": "0.2.0",
 				"commander": "^7.2.0",
 				"css-select": "^5.1.0",
-				"css-tree": "^2.2.1",
+				"css-tree": "^2.3.1",
+				"css-what": "^6.1.0",
 				"csso": "^5.0.5",
 				"picocolors": "^1.0.0"
 			},
@@ -4857,6 +4859,25 @@
 			"engines": {
 				"node": ">= 10"
 			}
+		},
+		"node_modules/svgo/node_modules/css-tree": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.0.30",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/svgo/node_modules/mdn-data": {
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+			"license": "CC0-1.0"
 		},
 		"node_modules/terser": {
 			"version": "5.32.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"mime-types": "^2.1.35",
 		"node-getopt": "git://github.com/tuxpoldo/node-getopt.git#05e498731c14b648fa332ca78d3a301c5e4be440",
 		"superagent": "^10.1.1",
-		"svgo": "^3.0.2"
+		"svgo": "^3.3.2"
 	},
 	"devDependencies": {
 		"jest": "^29.7.0",


### PR DESCRIPTION
Checking https://github.com/svg/svgo/releases/tag/v3.3.2 and the previous releases, it doesn't look like there are any breaking changes here. There were some that were reverted and held off for the 4.0 release.