### PR TITLE
temporary dashicons.css workaround for file requests

### DIFF
--- a/routes/file.js
+++ b/routes/file.js
@@ -40,7 +40,10 @@ module.exports = async ( request, reply ) => {
 		do_minify = false;
 	}
 
-	if ( path.match( /\.(dev|min)\./ ) ) {
+	if ( do_minify && path.match( /\.(dev|min)\./ ) ) {
+		do_minify = false;
+	}
+	if ( do_minify && ( path.endsWith( 'dashicons.css' ) || path.endsWith( 'dashicons.min.css' ) ) ) {
 		do_minify = false;
 	}
 	log.minify = do_minify;

--- a/routes/file.js
+++ b/routes/file.js
@@ -43,7 +43,7 @@ module.exports = async ( request, reply ) => {
 	if ( do_minify && path.match( /\.(dev|min)\./ ) ) {
 		do_minify = false;
 	}
-	if ( do_minify && ( path.endsWith( 'dashicons.css' ) || path.endsWith( 'dashicons.min.css' ) ) ) {
+	if ( do_minify && path.endsWith( 'dashicons.css' ) ) {
 		do_minify = false;
 	}
 	log.minify = do_minify;


### PR DESCRIPTION
http://localhost:4747/file?path=dashicons.css and http://localhost:4747/file?path=tests/dashicons.css should no longer be minimized with this PR

This is a workaround for some minifiers changing strings like `"\f148"` to utf-8, which isn't always parsed properly