### PR TITLE
switch css minification to cssnano (using cssnano-preset-lite)

### DIFF
--- a/lib/css-min.js
+++ b/lib/css-min.js
@@ -1,4 +1,14 @@
-module.exports = ( body ) => {
-	const csso = require( 'csso' );
-	return csso.minify( body, { restructure: false } ).css;
+module.exports = async (body) => {
+	const postcss = require( 'postcss' );
+	const cssnano = require( 'cssnano' );
+
+	try {
+		const result = await postcss( [ cssnano ] )
+			.process( body, { from: undefined } ) // Add `from` option to avoid warnings, telling PostCSS this doesn't come from a file
+			.then( result => result.css );
+		return result;
+	} catch ( error ) {
+		console.error( 'PostCSS processing error:', error );
+		throw error;
+	}
 };

--- a/lib/css-min.js
+++ b/lib/css-min.js
@@ -1,11 +1,11 @@
-module.exports = async (body) => {
+module.exports = async ( body ) => {
 	const postcss = require( 'postcss' );
 	const cssnano = require( 'cssnano' );
 
 	try {
 		const result = await postcss( [ cssnano ] )
 			.process( body, { from: undefined } ) // Add `from` option to avoid warnings, telling PostCSS this doesn't come from a file
-			.then( result => result.css );
+			.then( ( result ) => result.css );
 		return result;
 	} catch ( error ) {
 		console.error( 'PostCSS processing error:', error );

--- a/lib/css-min.js
+++ b/lib/css-min.js
@@ -1,9 +1,14 @@
 module.exports = async ( body ) => {
 	const postcss = require( 'postcss' );
 	const cssnano = require( 'cssnano' );
+	const cssnanoPresetLite = require( 'cssnano-preset-lite' );
 
 	try {
-		const result = await postcss( [ cssnano ] )
+		const result = await postcss( [
+			cssnano( {
+				preset: cssnanoPresetLite,
+			} ),
+		] )
 			.process( body, { from: undefined } ) // Add `from` option to avoid warnings, telling PostCSS this doesn't come from a file
 			.then( ( result ) => result.css );
 		return result;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"@swc/core": "^1.10.4",
 				"cssnano": "^7.0.6",
+				"cssnano-preset-lite": "^4.0.3",
 				"csso": "^5.0.5",
 				"fastify": "^5.2.1",
 				"generic-pool": "^3.9.0",
@@ -2236,6 +2237,24 @@
 				"postcss-reduce-transforms": "^7.0.0",
 				"postcss-svgo": "^7.0.1",
 				"postcss-unique-selectors": "^7.0.3"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/cssnano-preset-lite": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-lite/-/cssnano-preset-lite-4.0.3.tgz",
+			"integrity": "sha512-/ckjMDvs0D7RrG2L/tVqEbfj7DmcRRVXShOBxVCJIYZZ7qnN55Ug05bBD+s6nAmx64IFpmJup8gysXwQ4zFCvg==",
+			"license": "MIT",
+			"dependencies": {
+				"cssnano-utils": "^5.0.0",
+				"postcss-discard-comments": "^7.0.3",
+				"postcss-discard-empty": "^7.0.0",
+				"postcss-normalize-whitespace": "^7.0.0"
 			},
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "8.2.1",
 			"dependencies": {
 				"@swc/core": "^1.10.4",
+				"cssnano": "^7.0.6",
 				"csso": "^5.0.5",
 				"fastify": "^5.2.1",
 				"generic-pool": "^3.9.0",
@@ -16,6 +17,7 @@
 				"jsonminify": "^0.4.2",
 				"mime-types": "^2.1.35",
 				"node-getopt": "git://github.com/tuxpoldo/node-getopt.git#05e498731c14b648fa332ca78d3a301c5e4be440",
+				"postcss": "^8.5.1",
 				"superagent": "^10.1.1",
 				"svgo": "^3.3.2"
 			},
@@ -1771,10 +1773,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.22.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-			"integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
-			"dev": true,
+			"version": "4.24.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1789,11 +1790,12 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001541",
-				"electron-to-chromium": "^1.4.535",
-				"node-releases": "^2.0.13",
-				"update-browserslist-db": "^1.0.13"
+				"caniuse-lite": "^1.0.30001688",
+				"electron-to-chromium": "^1.5.73",
+				"node-releases": "^2.0.19",
+				"update-browserslist-db": "^1.1.1"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -1885,11 +1887,22 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/caniuse-api": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+			"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.0.0",
+				"caniuse-lite": "^1.0.0",
+				"lodash.memoize": "^4.1.2",
+				"lodash.uniq": "^4.5.0"
+			}
+		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001565",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
-			"integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
-			"dev": true,
+			"version": "1.0.30001695",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+			"integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1903,7 +1916,8 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			]
+			],
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -2011,6 +2025,12 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
+		"node_modules/colord": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+			"license": "MIT"
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2097,6 +2117,18 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-declaration-sorter": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
+			"integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.9"
+			}
+		},
 		"node_modules/css-select": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -2134,6 +2166,94 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cssesc": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+			"license": "MIT",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/cssnano": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.6.tgz",
+			"integrity": "sha512-54woqx8SCbp8HwvNZYn68ZFAepuouZW4lTwiMVnBErM3VkO7/Sd4oTOt3Zz3bPx3kxQ36aISppyXj2Md4lg8bw==",
+			"license": "MIT",
+			"dependencies": {
+				"cssnano-preset-default": "^7.0.6",
+				"lilconfig": "^3.1.2"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/cssnano"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/cssnano-preset-default": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.6.tgz",
+			"integrity": "sha512-ZzrgYupYxEvdGGuqL+JKOY70s7+saoNlHSCK/OGn1vB2pQK8KSET8jvenzItcY+kA7NoWvfbb/YhlzuzNKjOhQ==",
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.23.3",
+				"css-declaration-sorter": "^7.2.0",
+				"cssnano-utils": "^5.0.0",
+				"postcss-calc": "^10.0.2",
+				"postcss-colormin": "^7.0.2",
+				"postcss-convert-values": "^7.0.4",
+				"postcss-discard-comments": "^7.0.3",
+				"postcss-discard-duplicates": "^7.0.1",
+				"postcss-discard-empty": "^7.0.0",
+				"postcss-discard-overridden": "^7.0.0",
+				"postcss-merge-longhand": "^7.0.4",
+				"postcss-merge-rules": "^7.0.4",
+				"postcss-minify-font-values": "^7.0.0",
+				"postcss-minify-gradients": "^7.0.0",
+				"postcss-minify-params": "^7.0.2",
+				"postcss-minify-selectors": "^7.0.4",
+				"postcss-normalize-charset": "^7.0.0",
+				"postcss-normalize-display-values": "^7.0.0",
+				"postcss-normalize-positions": "^7.0.0",
+				"postcss-normalize-repeat-style": "^7.0.0",
+				"postcss-normalize-string": "^7.0.0",
+				"postcss-normalize-timing-functions": "^7.0.0",
+				"postcss-normalize-unicode": "^7.0.2",
+				"postcss-normalize-url": "^7.0.0",
+				"postcss-normalize-whitespace": "^7.0.0",
+				"postcss-ordered-values": "^7.0.1",
+				"postcss-reduce-initial": "^7.0.2",
+				"postcss-reduce-transforms": "^7.0.0",
+				"postcss-svgo": "^7.0.1",
+				"postcss-unique-selectors": "^7.0.3"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/cssnano-utils": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.0.tgz",
+			"integrity": "sha512-Uij0Xdxc24L6SirFr25MlwC2rCFX6scyUmuKpzI+JQ7cyqDEwD42fJ0xfB3yLfOnRDU5LKGgjQ9FA6LYh76GWQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
 			}
 		},
 		"node_modules/csso": {
@@ -2301,10 +2421,10 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.595",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.595.tgz",
-			"integrity": "sha512-+ozvXuamBhDOKvMNUQvecxfbyICmIAwS4GpLmR0bsiSBlGnLaOcs2Cj7J8XSbW+YEaN3Xl3ffgpm+srTUWFwFQ==",
-			"dev": true
+			"version": "1.5.87",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.87.tgz",
+			"integrity": "sha512-mPFwmEWmRivw2F8x3w3l2m6htAUN97Gy0kwpO++2m9iT1Gt8RCFVUfv9U/sIbHJ6rY4P6/ooqFL/eL7ock+pPg==",
+			"license": "ISC"
 		},
 		"node_modules/emittery": {
 			"version": "0.13.1",
@@ -2364,10 +2484,10 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-			"dev": true,
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -3771,6 +3891,18 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/lilconfig": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antonk52"
+			}
+		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -3788,6 +3920,18 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+			"license": "MIT"
 		},
 		"node_modules/lower-case": {
 			"version": "2.0.2",
@@ -3920,6 +4064,24 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
+		"node_modules/nanoid": {
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3952,10 +4114,10 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
-			"dev": true
+			"version": "2.0.19",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"license": "MIT"
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -4154,9 +4316,10 @@
 			"dev": true
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -4225,6 +4388,516 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+			"integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.8",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/postcss-calc": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.0.tgz",
+			"integrity": "sha512-uQ/LDGsf3mgsSUEXmAt3VsCSHR3aKqtEIkmB+4PhzYwRYOW5MZs/GhCCFpsOtJJkP6EC6uGipbrnaTjqaJZcJw==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-selector-parser": "^7.0.0",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12 || ^20.9 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.38"
+			}
+		},
+		"node_modules/postcss-colormin": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.2.tgz",
+			"integrity": "sha512-YntRXNngcvEvDbEjTdRWGU606eZvB5prmHG4BF0yLmVpamXbpsRJzevyy6MZVyuecgzI2AWAlvFi8DAeCqwpvA==",
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.23.3",
+				"caniuse-api": "^3.0.0",
+				"colord": "^2.9.3",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-convert-values": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.4.tgz",
+			"integrity": "sha512-e2LSXPqEHVW6aoGbjV9RsSSNDO3A0rZLCBxN24zvxF25WknMPpX8Dm9UxxThyEbaytzggRuZxaGXqaOhxQ514Q==",
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.23.3",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-discard-comments": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.3.tgz",
+			"integrity": "sha512-q6fjd4WU4afNhWOA2WltHgCbkRhZPgQe7cXF74fuVB/ge4QbM9HEaOIzGSiMvM+g/cOsNAUGdf2JDzqA2F8iLA==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-selector-parser": "^6.1.2"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-discard-comments/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-discard-duplicates": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.1.tgz",
+			"integrity": "sha512-oZA+v8Jkpu1ct/xbbrntHRsfLGuzoP+cpt0nJe5ED2FQF8n8bJtn7Bo28jSmBYwqgqnqkuSXJfSUEE7if4nClQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-discard-empty": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.0.tgz",
+			"integrity": "sha512-e+QzoReTZ8IAwhnSdp/++7gBZ/F+nBq9y6PomfwORfP7q9nBpK5AMP64kOt0bA+lShBFbBDcgpJ3X4etHg4lzA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-discard-overridden": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.0.tgz",
+			"integrity": "sha512-GmNAzx88u3k2+sBTZrJSDauR0ccpE24omTQCVmaTTZFz1du6AasspjaUPMJ2ud4RslZpoFKyf+6MSPETLojc6w==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-merge-longhand": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.4.tgz",
+			"integrity": "sha512-zer1KoZA54Q8RVHKOY5vMke0cCdNxMP3KBfDerjH/BYHh4nCIh+1Yy0t1pAEQF18ac/4z3OFclO+ZVH8azjR4A==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0",
+				"stylehacks": "^7.0.4"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-merge-rules": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.4.tgz",
+			"integrity": "sha512-ZsaamiMVu7uBYsIdGtKJ64PkcQt6Pcpep/uO90EpLS3dxJi6OXamIobTYcImyXGoW0Wpugh7DSD3XzxZS9JCPg==",
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.23.3",
+				"caniuse-api": "^3.0.0",
+				"cssnano-utils": "^5.0.0",
+				"postcss-selector-parser": "^6.1.2"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-minify-font-values": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.0.tgz",
+			"integrity": "sha512-2ckkZtgT0zG8SMc5aoNwtm5234eUx1GGFJKf2b1bSp8UflqaeFzR50lid4PfqVI9NtGqJ2J4Y7fwvnP/u1cQog==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-minify-gradients": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.0.tgz",
+			"integrity": "sha512-pdUIIdj/C93ryCHew0UgBnL2DtUS3hfFa5XtERrs4x+hmpMYGhbzo6l/Ir5de41O0GaKVpK1ZbDNXSY6GkXvtg==",
+			"license": "MIT",
+			"dependencies": {
+				"colord": "^2.9.3",
+				"cssnano-utils": "^5.0.0",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-minify-params": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.2.tgz",
+			"integrity": "sha512-nyqVLu4MFl9df32zTsdcLqCFfE/z2+f8GE1KHPxWOAmegSo6lpV2GNy5XQvrzwbLmiU7d+fYay4cwto1oNdAaQ==",
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.23.3",
+				"cssnano-utils": "^5.0.0",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-minify-selectors": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.4.tgz",
+			"integrity": "sha512-JG55VADcNb4xFCf75hXkzc1rNeURhlo7ugf6JjiiKRfMsKlDzN9CXHZDyiG6x/zGchpjQS+UAgb1d4nqXqOpmA==",
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"postcss-selector-parser": "^6.1.2"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-normalize-charset": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.0.tgz",
+			"integrity": "sha512-ABisNUXMeZeDNzCQxPxBCkXexvBrUHV+p7/BXOY+ulxkcjUZO0cp8ekGBwvIh2LbCwnWbyMPNJVtBSdyhM2zYQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-display-values": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.0.tgz",
+			"integrity": "sha512-lnFZzNPeDf5uGMPYgGOw7v0BfB45+irSRz9gHQStdkkhiM0gTfvWkWB5BMxpn0OqgOQuZG/mRlZyJxp0EImr2Q==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-positions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.0.tgz",
+			"integrity": "sha512-I0yt8wX529UKIGs2y/9Ybs2CelSvItfmvg/DBIjTnoUSrPxSV7Z0yZ8ShSVtKNaV/wAY+m7bgtyVQLhB00A1NQ==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-repeat-style": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.0.tgz",
+			"integrity": "sha512-o3uSGYH+2q30ieM3ppu9GTjSXIzOrRdCUn8UOMGNw7Af61bmurHTWI87hRybrP6xDHvOe5WlAj3XzN6vEO8jLw==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-string": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.0.tgz",
+			"integrity": "sha512-w/qzL212DFVOpMy3UGyxrND+Kb0fvCiBBujiaONIihq7VvtC7bswjWgKQU/w4VcRyDD8gpfqUiBQ4DUOwEJ6Qg==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-timing-functions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.0.tgz",
+			"integrity": "sha512-tNgw3YV0LYoRwg43N3lTe3AEWZ66W7Dh7lVEpJbHoKOuHc1sLrzMLMFjP8SNULHaykzsonUEDbKedv8C+7ej6g==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-unicode": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.2.tgz",
+			"integrity": "sha512-ztisabK5C/+ZWBdYC+Y9JCkp3M9qBv/XFvDtSw0d/XwfT3UaKeW/YTm/MD/QrPNxuecia46vkfEhewjwcYFjkg==",
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.23.3",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-url": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.0.tgz",
+			"integrity": "sha512-+d7+PpE+jyPX1hDQZYG+NaFD+Nd2ris6r8fPTBAjE8z/U41n/bib3vze8x7rKs5H1uEw5ppe9IojewouHk0klQ==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-whitespace": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.0.tgz",
+			"integrity": "sha512-37/toN4wwZErqohedXYqWgvcHUGlT8O/m2jVkAfAe9Bd4MzRqlBmXrJRePH0e9Wgnz2X7KymTgTOaaFizQe3AQ==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-ordered-values": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.1.tgz",
+			"integrity": "sha512-irWScWRL6nRzYmBOXReIKch75RRhNS86UPUAxXdmW/l0FcAsg0lvAXQCby/1lymxn/o0gVa6Rv/0f03eJOwHxw==",
+			"license": "MIT",
+			"dependencies": {
+				"cssnano-utils": "^5.0.0",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-reduce-initial": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.2.tgz",
+			"integrity": "sha512-pOnu9zqQww7dEKf62Nuju6JgsW2V0KRNBHxeKohU+JkHd/GAH5uvoObqFLqkeB2n20mr6yrlWDvo5UBU5GnkfA==",
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.23.3",
+				"caniuse-api": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-reduce-transforms": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.0.tgz",
+			"integrity": "sha512-pnt1HKKZ07/idH8cpATX/ujMbtOGhUfE+m8gbqwJE05aTaNw8gbo34a2e3if0xc0dlu75sUOiqvwCGY3fzOHew==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-selector-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+			"integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-svgo": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.0.1.tgz",
+			"integrity": "sha512-0WBUlSL4lhD9rA5k1e5D8EN5wCEyZD6HJk0jIvRxl+FDVOMlJ7DePHYWGGVc5QRqrJ3/06FTXM0bxjmJpmTPSA==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0",
+				"svgo": "^3.3.2"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >= 18"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-unique-selectors": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.3.tgz",
+			"integrity": "sha512-J+58u5Ic5T1QjP/LDV9g3Cx4CNOgB5vz+kM6+OxHHhFACdcDeKhBXjQmB7fnIZM12YSTvsL0Opwco83DmacW2g==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-selector-parser": "^6.1.2"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-unique-selectors/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"license": "MIT"
 		},
 		"node_modules/prettier": {
 			"name": "wp-prettier",
@@ -4629,9 +5302,10 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4747,6 +5421,35 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/stylehacks": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.4.tgz",
+			"integrity": "sha512-i4zfNrGMt9SB4xRK9L83rlsFCgdGANfeDAYacO1pkqcE7cRHPdWHwnKZVz7WY17Veq/FvyYsRAU++Ga+qDFIww==",
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.23.3",
+				"postcss-selector-parser": "^6.1.2"
+			},
+			"engines": {
+				"node": "^18.12.0 || ^20.9.0 || >=22.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/stylehacks/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/superagent": {
@@ -5005,10 +5708,9 @@
 			"dev": true
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
-			"dev": true,
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+			"integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5023,9 +5725,10 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -5033,6 +5736,12 @@
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	},
 	"dependencies": {
 		"@swc/core": "^1.10.4",
+		"cssnano": "^7.0.6",
 		"csso": "^5.0.5",
 		"fastify": "^5.2.1",
 		"generic-pool": "^3.9.0",
@@ -15,6 +16,7 @@
 		"jsonminify": "^0.4.2",
 		"mime-types": "^2.1.35",
 		"node-getopt": "git://github.com/tuxpoldo/node-getopt.git#05e498731c14b648fa332ca78d3a301c5e4be440",
+		"postcss": "^8.5.1",
 		"superagent": "^10.1.1",
 		"svgo": "^3.3.2"
 	},

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"dependencies": {
 		"@swc/core": "^1.10.4",
 		"cssnano": "^7.0.6",
+		"cssnano-preset-lite": "^4.0.3",
 		"csso": "^5.0.5",
 		"fastify": "^5.2.1",
 		"generic-pool": "^3.9.0",

--- a/tests/file-css.test.js
+++ b/tests/file-css.test.js
@@ -30,6 +30,31 @@ describe( 'file (css): Minify CSS files', () => {
 		);
 	} );
 
+	test( 'GET `/file` -- CSS preserves Unicode escape sequences', async () => {
+		const target_url = 'tests/files/test-unicode.css';
+		const originalContent = await fs.readFile( target_url, 'utf8' );
+
+		const resp = await request
+			.get( `/file?path=${ target_url }` )
+			.expect( 200 )
+			.expect( 'Content-Type', /text\/css/ )
+			.expect( 'x-minify', 't' );
+
+		const minifiedText = resp.text;
+
+		// Verify Unicode escape sequence is preserved
+		expect( minifiedText ).toContain( '"\\f148"' );
+
+		// Also verify basic minification (whitespace removal etc)
+		expect( minifiedText.length ).toBeLessThan( originalContent.length );
+		console.info(
+			`Minimized CSS ${ target_url } to ${ (
+				( minifiedText.length / originalContent.length ) *
+				100
+			).toFixed( 2 ) }% of original size`,
+		);
+	} );
+
 	test( 'GET `/file` -- CSS minify supports nesting :where(& > .bar)', async () => {
 		// This is from https://github.com/evanw/esbuild/issues/4005
 		const target_url = 'tests/files/nesting-test.css';

--- a/tests/file-css.test.js
+++ b/tests/file-css.test.js
@@ -11,11 +11,14 @@ describe( 'file (css): Minify CSS files', () => {
 		const target_url = 'tests/files/bootstrap.css';
 		const originalContent = await fs.readFile( target_url, 'utf8' );
 
+		const startTime = process.hrtime();
 		const resp = await request
 			.get( `/file?path=${ target_url }` )
 			.expect( 200 )
 			.expect( 'Content-Type', /text\/css/ )
 			.expect( 'x-minify', 't' );
+		const [ seconds, nanoseconds ] = process.hrtime( startTime );
+		const milliseconds = seconds * 1000 + nanoseconds / 1000000;
 
 		const minifiedText = resp.text;
 
@@ -26,7 +29,7 @@ describe( 'file (css): Minify CSS files', () => {
 		console.info(
 			`Minimized CSS ${ target_url } to ${ ( ( minifiedSize / originalSize ) * 100 ).toFixed(
 				2,
-			) }% of original size`,
+			) }% of original size in ${ milliseconds.toFixed( 2 ) }ms`,
 		);
 	} );
 
@@ -34,11 +37,14 @@ describe( 'file (css): Minify CSS files', () => {
 		const target_url = 'tests/files/test-unicode.css';
 		const originalContent = await fs.readFile( target_url, 'utf8' );
 
+		const startTime = process.hrtime();
 		const resp = await request
 			.get( `/file?path=${ target_url }` )
 			.expect( 200 )
 			.expect( 'Content-Type', /text\/css/ )
 			.expect( 'x-minify', 't' );
+		const [ seconds, nanoseconds ] = process.hrtime( startTime );
+		const milliseconds = seconds * 1000 + nanoseconds / 1000000;
 
 		const minifiedText = resp.text;
 
@@ -51,7 +57,7 @@ describe( 'file (css): Minify CSS files', () => {
 			`Minimized CSS ${ target_url } to ${ (
 				( minifiedText.length / originalContent.length ) *
 				100
-			).toFixed( 2 ) }% of original size`,
+			).toFixed( 2 ) }% of original size in ${ milliseconds.toFixed( 2 ) }ms`,
 		);
 	} );
 

--- a/tests/files/test-unicode.css
+++ b/tests/files/test-unicode.css
@@ -1,4 +1,4 @@
-/* test3.css */
+/* test-unicode.css */
 .test:before {
     content: "\f148";
 }

--- a/tests/files/test-unicode.css
+++ b/tests/files/test-unicode.css
@@ -1,0 +1,4 @@
+/* test3.css */
+.test:before {
+    content: "\f148";
+}


### PR DESCRIPTION
We found a bug that happens when minifying files like WP's dashicons.css.

It uses unicode escapes like so:
```css
.dashicons-sticky:before {
	content: "\f537";
}

.dashicons-store:before {
	content: "\f513";
}

.dashicons-superhero-alt:before {
	content: "\f197";
}
```

The current engine turns these into unicode codepoints, then renders them in utf-8 bytes. If the browser decides to interpret the file as ASCII, or another non-utf8 encoding, then the user will see 文字化け (mojibake) instead of their icon.

CSSNano is the only engine we've found that both leaves unicode escapes alone, and supports advanced CSS directives without removing or breaking them. The only drawback has been that it's slow in it's default config (~600ms for bootstrap on my laptop.)

Enter, the lite preset. With the light preset, we get a fast response time (~100ms on my laptop) while getting the main minification benefit and not giving up too much.

Comparison of CSSNano presets (and the trunk CSSO) on bootstrap.css:
```
timestamp,preset,originalSize,minifiedSize,compressionRatio,processingTime
2025-01-29T20:07:20.311Z,advanced,173597,126669,72.97,669.35
2025-01-29T20:07:24.010Z,advanced,173597,126669,72.97,476.25
2025-01-29T20:07:38.613Z,advanced,173597,126669,72.97,628.75
2025-01-29T20:07:48.524Z,advanced,173597,126669,72.97,508.25
2025-01-29T20:07:54.346Z,advanced,173597,126669,72.97,663.40
2025-01-29T20:08:36.311Z,default,173597,139520,80.37,627.10
2025-01-29T20:08:40.289Z,default,173597,139520,80.37,611.02
2025-01-29T20:08:50.079Z,default,173597,139520,80.37,638.39
2025-01-29T20:08:59.668Z,default,173597,139520,80.37,448.40
2025-01-29T20:09:05.137Z,default,173597,139520,80.37,458.37
2025-01-29T20:10:42.450Z,lite,173597,143824,82.85,92.92
2025-01-29T20:10:45.248Z,lite,173597,143824,82.85,105.12
2025-01-29T20:10:48.558Z,lite,173597,143824,82.85,101.39
2025-01-29T20:11:01.099Z,lite,173597,143824,82.85,110.11
2025-01-29T20:11:04.648Z,lite,173597,143824,82.85,141.38
2025-01-29T20:14:13.802Z,trunk csso,173597,140861,81.14,144.16
2025-01-29T20:14:16.637Z,trunk csso,173597,140861,81.14,152.86
2025-01-29T20:14:19.279Z,trunk csso,173597,140861,81.14,171.55
2025-01-29T20:14:22.247Z,trunk csso,173597,140861,81.14,158.34
```