### PR TITLE
CSS Minification: Add test covering nesting :where(& > .bar)

### DIFF
--- a/tests/file-css.test.js
+++ b/tests/file-css.test.js
@@ -29,4 +29,31 @@ describe( 'file (css): Minify CSS files', () => {
 			) }% of original size`,
 		);
 	} );
+
+	test( 'GET `/file` -- CSS minify supports nesting :where(& > .bar)', async () => {
+		// This is from https://github.com/evanw/esbuild/issues/4005
+		const target_url = 'tests/files/nesting-test.css';
+		const originalContent = await fs.readFile( target_url, 'utf8' );
+
+		const resp = await request
+			.get( `/file?path=${ target_url }` )
+			.expect( 200 )
+			.expect( 'Content-Type', /text\/css/ )
+			.expect( 'x-minify', 't' );
+
+		const minifiedText = resp.text;
+		// Verify it was actually minified
+		const originalSize = originalContent.length;
+		const minifiedSize = minifiedText.length;
+		expect( minifiedSize ).toBeLessThan( originalSize * 0.85 );
+
+		// Verify the "purple" rule was not removed
+		expect( minifiedText ).toContain( 'purple' );
+
+		console.info(
+			`Minimized CSS ${ target_url } to ${ ( ( minifiedSize / originalSize ) * 100 ).toFixed(
+				2,
+			) }% of original size`,
+		);
+	} );
 } );

--- a/tests/files/nesting-test.css
+++ b/tests/files/nesting-test.css
@@ -1,0 +1,10 @@
+/* From https://github.com/evanw/esbuild/issues/4005 */
+.foo {
+  color: red;
+}
+
+.foo {
+  :where(& > .bar) {
+    color: purple;
+  }
+}


### PR DESCRIPTION
This is from https://github.com/evanw/esbuild/issues/4005.

Our current engine does not pass this test, so it will fail.