### PR TITLE
cssmin: handle invalid CSS

### DIFF
--- a/lib/css-min.js
+++ b/lib/css-min.js
@@ -13,7 +13,14 @@ module.exports = async ( body ) => {
 			.then( ( result ) => result.css );
 		return result;
 	} catch ( error ) {
-		console.error( 'PostCSS processing error:', error );
-		throw error;
+		console.error( '{ '
+			+ ' "error": true, '
+			+ ' "msg": "PostCSS processing error", '
+			+ ' "reason": "' + error.reason + '", '
+			+ ' "line": ' + error.line + ', '
+			+ ' "column": ' + error.column
+			+ ' } '
+		);
+		return body;
 	}
 };

--- a/tests/get-svg.test.js
+++ b/tests/get-svg.test.js
@@ -2,7 +2,7 @@
 
 const { getSharedServerPort } = require( './test-server-utils' );
 const supertest = require( 'supertest' );
-const target_url = 'https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/svg2009.svg';
+const target_url = 'https://s0.wp.com/wp-content/themes/h4/assets/hosting/globe-blue.svg';
 
 describe( 'get-svg: Default environment', () => {
 	let request = supertest( `http://localhost:${ getSharedServerPort() }` );


### PR DESCRIPTION
When we are asked to process invalid CSS, skip minifying and return the origina