### PR TITLE
Add /raw-get/ route to handle CSS Concat URLs with double ?? without extra encoding

### DIFF
--- a/routes/raw-get.js
+++ b/routes/raw-get.js
@@ -1,0 +1,142 @@
+module.exports = async ( request, reply ) => {
+	const superagent = require( 'superagent' );
+	const minify = require( '../lib/minify' );
+	const compress = require( '../lib/compress' );
+	const { envBool } = require( '../lib/util' );
+	const { performance } = require( 'perf_hooks' );
+
+	// 1) rawUrl might be:
+	//    "/raw-get/https://automattic.com/_static/??-stuff&cssminify=yes"
+	const rawUrl = request.raw.url;
+
+	// 2) strip "/raw-get/" from the front
+	let prefix = '/raw-get/';
+	let finalUrl = rawUrl.startsWith( prefix ) ? rawUrl.slice( prefix.length ) : rawUrl;
+
+	// 3) remove `cssminify=yes` if present
+	// Do not use URL parameter parsing - it's too easy to destroy the "??" (double question) used in cssConcat
+	let do_minify = false;
+
+	const removeCssMinify =
+		/(\?cssminify=yes&)|(\?cssminify=yes)|(&cssminify=yes&)|(&cssminify=yes)/gi;
+	finalUrl = finalUrl.replace( removeCssMinify, ( match, g1, g2, g3, g4 ) => {
+		// The presence of match means we found 'cssminify=yes'
+		do_minify = true;
+
+		if ( g1 ) {
+			// "?cssminify=yes&" => remove 'cssminify=yes&', keep '?'
+			return '?';
+		}
+		if ( g2 ) {
+			// "?cssminify=yes" => remove entire thing
+			return '';
+		}
+		if ( g3 ) {
+			// "&cssminify=yes&" => remove 'cssminify=yes&', keep '&'
+			return '&';
+		}
+		if ( g4 ) {
+			// "&cssminify=yes" => remove entire thing
+			return '';
+		}
+		return ''; // fallback, should never happen
+	} );
+
+	// Allow ?with=gzip or ?level=9 from the local query.
+	let accept = request.headers[ 'accept-encoding' ];
+	if ( typeof request.query.with === 'string' ) {
+		accept = request.query.with;
+	}
+	let level = 5;
+	if ( typeof request.query.level === 'string' ) {
+		level = parseInt( request.query.level, 10 );
+	}
+
+	/*
+	console.log({
+		rawUrl,
+		finalUrl,
+		do_minify
+	});
+	*/
+
+	// if finalUrl is empty or obviously invalid, handle that:
+	if ( ! finalUrl.startsWith( 'http' ) ) {
+		return reply.code( 400 ).send( { error: 'Invalid or missing URL' } );
+	}
+
+	// 4) fetch the resource
+	const start = performance.now();
+	try {
+		const resp = await superagent.get( finalUrl );
+		const ms = performance.now() - start;
+		return sendReply( reply, resp, do_minify, accept, level, ms );
+	} catch ( err ) {
+		return reply.code( 502 ).send( { error: err.message } );
+	}
+
+	async function sendReply( reply, resp, doMinify, accept, level, ms ) {
+		let body = resp.text || resp.body.toString();
+		let contentType = resp.headers[ 'content-type' ] || '';
+
+		let log = {
+			origin_get_ms: parseInt( ms ),
+			finalUrl,
+			do_minify,
+			contentType,
+			original_size: body.length,
+		};
+
+		if ( ! doMinify ) {
+			showLog( log );
+			return reply
+				.code( 200 )
+				.header( 'Content-Type', contentType )
+				.header( 'x-minify', 'f' )
+				.send( body );
+		}
+
+		// Minify
+		const minifyStart = performance.now();
+		const [ minified, detectedType ] = await minify( body, contentType );
+		log.minify_ms = parseInt( performance.now() - minifyStart );
+		log.type = detectedType;
+		log.minify_size = minified.length;
+		log.minify_diff = log.original_size - log.minify_size;
+
+		let finalBody = minified;
+		let encoding = null;
+		let doCompress = true;
+		if ( envBool( 'MINIFIERS_DISABLE_COMPRESSION' ) ) {
+			doCompress = false;
+		} else if ( ! detectedType ) {
+			doCompress = false;
+		}
+		if ( doCompress ) {
+			const compressStart = performance.now();
+			const [ compressed, enc ] = compress( minified, accept, level );
+			if ( enc ) {
+				encoding = enc;
+				finalBody = compressed;
+				log.compress_ms = parseInt( performance.now() - compressStart );
+				log.compress_size = finalBody.length;
+				log.compress_diff = log.minify_size - log.compress_size;
+			}
+		}
+
+		showLog( log );
+		const r = reply.code( 200 ).header( 'Content-Type', contentType );
+		if ( encoding ) {
+			r.header( 'Content-Encoding', encoding );
+			r.header( 'x-minify-compression-level', level );
+		}
+		r.header( 'x-minify', 't' );
+		r.send( finalBody );
+	}
+
+	function showLog( obj ) {
+		if ( ! process.env.DEBUG_QUIET_REQUEST ) {
+			console.log( JSON.stringify( obj ) );
+		}
+	}
+};

--- a/server.js
+++ b/server.js
@@ -23,6 +23,8 @@ server.get( '/file', require( './routes/file' ) );
 server.get( '/get', require( './routes/get' ) );
 server.options( '/get', require( './routes/get' ) );
 
+server.get( '/raw-get/*', require( './routes/raw-get' ) );
+
 // Take care of command line options
 const opt = require( 'node-getopt' )
 	.create( [ [ 'p', 'port=4747', 'The TCP port that the web server will listen on.', 4747 ] ] )

--- a/tests/raw-get-css.test.js
+++ b/tests/raw-get-css.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { getSharedServerPort } = require( './test-server-utils' );
+const supertest = require( 'supertest' );
+
+// Example “CSS Concat” URL with double question marks.
+// Also has "&cssminify=yes" so we test the server's logic for removing that.
+const concatUrl =
+	'https://automattic.com/_static/??-eJx9j8sOAiEMRX/I2owmDhvjtzClIgYo4TH+vqhxoht296bnJLfoMEp1JLFsYU+l7PCRoJfKsWJokHyz7sNwQW2Ci7DoDOthRGdevNgeLXbqp44kywJeSFcn8a/A1WuXR6pWBFXE92VYWuIM29Kh9oX6nSSA4aXZ93uBA2m6sXnpl3Ce5qNSp1lN6v4EdUpz2w==&cssminify=yes';
+
+describe( 'raw-get-css: Default environment', () => {
+	// Create a supertest instance pointing to our local server
+	let request = supertest( `http://localhost:${ getSharedServerPort() }` );
+
+	test( 'GET `/raw-get/` -- CSS Concat URL with cssminify=yes', async () => {
+		// We build the path by simply appending the entire concatUrl after '/raw-get/'.
+		// We do NOT URL-encode the double question marks, to confirm our “raw-get” logic works.
+		const rawPath = '/raw-get/' + concatUrl;
+
+		const resp = await request
+			.get( rawPath )
+			.expect( 200 )
+			.expect( 'Content-Type', /text\/css/ )
+			.expect( 'x-minify', 't' ); // because we expect minification to be active
+
+		// Confirm it returned *some* CSS.
+		expect( resp.text ).toMatch( /body|html/ );
+	} );
+} );


### PR DESCRIPTION
This PR adds a new `/raw-get/*` endpoint that **avoids** the usual query‐string parsing so we can preserve double question marks (`??`) used in CSS Concat URLs. It simply looks for `cssminify=yes` in the raw path, removes that parameter, and performs the same minification+compression routine as /get. This resolves the issue where the old `/get?url=…` approach would break on unencoded `??` or `+`.

### Testing

`npm start`

then test direct cssconcat:
```
curl 'https://automattic.com/_static/??-eJx9j8sOAiEMRX/I2owmDhvjtzClIgYo4TH+vqhxoht296bnJLfoMEp1JLFsYU+l7PCRoJfKsWJokHyz7sNwQW2Ci7DoDOthRGdevNgeLXbqp44kywJeSFcn8a/A1WuXR6pWBFXE92VYWuIM29Kh9oX6nSSA4aXZ93uBA2m6sXnpl3Ce5qNSp1lN6v4EdUpz2w==&cssminify=yes' -I
```

then test minifiers->cssconcat:
```
curl 'http://127.0.0.1:4747/raw-get/https://automattic.com/_static/??-eJx9j8sOAiEMRX/I2owmDhvjtzClIgYo4TH+vqhxoht296bnJLfoMEp1JLFsYU+l7PCRoJfKsWJokHyz7sNwQW2Ci7DoDOthRGdevNgeLXbqp44kywJeSFcn8a/A1WuXR6pWBFXE92VYWuIM29Kh9oX6nSSA4aXZ93uBA2m6sXnpl3Ce5qNSp1lN6v4EdUpz2w==&cssminify=yes' -I
```

note the second url is the same as the first with `http://127.0.0.1:4747/raw-get/` prepended - no extra encoding needed
