### PR TITLE
Update mime-types 2.1.35 -> 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"generic-pool": "^3.9.0",
 				"html-minifier-terser": "^7.2.0",
 				"jsonminify": "^0.4.2",
-				"mime-types": "^2.1.35",
+				"mime-types": "^3.0.1",
 				"node-getopt": "git://github.com/tuxpoldo/node-getopt.git#05e498731c14b648fa332ca78d3a301c5e4be440",
 				"postcss": "^8.5.6",
 				"superagent": "^10.2.2",
@@ -3202,6 +3202,27 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/form-data/node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/form-data/node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/formidable": {
 			"version": "3.5.4",
 			"resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -4513,19 +4534,21 @@
 			}
 		},
 		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+			"license": "MIT",
 			"dependencies": {
-				"mime-db": "1.52.0"
+				"mime-db": "^1.54.0"
 			},
 			"engines": {
 				"node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"generic-pool": "^3.9.0",
 		"html-minifier-terser": "^7.2.0",
 		"jsonminify": "^0.4.2",
-		"mime-types": "^2.1.35",
+		"mime-types": "^3.0.1",
 		"node-getopt": "git://github.com/tuxpoldo/node-getopt.git#05e498731c14b648fa332ca78d3a301c5e4be440",
 		"postcss": "^8.5.6",
 		"superagent": "^10.2.2",

--- a/tests/file-js.test.js
+++ b/tests/file-js.test.js
@@ -15,7 +15,7 @@ describe( 'file (js): Minify and execute minified code', () => {
 		const resp = await request
 			.get( `/file?path=${ target_url }` )
 			.expect( 200 )
-			.expect( 'Content-Type', /application\/javascript/ )
+			.expect( 'Content-Type', /text\/javascript/ )
 			.expect( 'x-minify', 't' );
 		const { text: minifiedText } = resp;
 
@@ -67,7 +67,7 @@ describe( 'file (js): Minify and execute minified code', () => {
 		const resp = await request
 			.get( `/file?path=${ target_url }` )
 			.expect( 200 )
-			.expect( 'Content-Type', /application\/javascript/ )
+			.expect( 'Content-Type', /text\/javascript/ )
 			.expect( 'x-minify', 't' );
 		const { text: minifiedText } = resp;
 
@@ -120,7 +120,7 @@ describe( 'file (js): Minify and execute minified code', () => {
 		const resp = await request
 			.get( `/file?path=${ target_url }` )
 			.expect( 200 )
-			.expect( 'Content-Type', /application\/javascript/ )
+			.expect( 'Content-Type', /text\/javascript/ )
 			.expect( 'x-minify', 't' );
 		const { text: minifiedText } = resp;
 


### PR DESCRIPTION
Note that this now returns `text/javascript` when using the /file path for JS files. It used to return `application/javascript`.
According to the RFC by quoted by stack overflow, `text/javascript` is now standard: https://stackoverflow.com/questions/21098865/text-javascript-vs-application-javascript

Note that there's now a mixture of types in our tests:
```
$ rg 'expect.*Content.*javascr'tests/file-js.test.js
18:                     .expect( 'Content-Type', /text\/javascript/ )
70:                     .expect( 'Content-Type', /text\/javascript/ )
123:                    .expect( 'Content-Type', /text\/javascript/ )

tests/get-js.test.js
14:                     .expect( 'Content-Type', /application\/javascript/ )
22:                     .expect( 'Content-Type', /application\/javascript/ )
31:                     .expect( 'Content-Type', /application\/javascript/ )
40:                     .expect( 'Content-Type', /application\/javascript/ )
49:                     .expect( 'Content-Type', /application\/javascript/ )

tests/env-get-js-compression.test.js
40:                     .expect( 'Content-Type', /application\/javascript/ )
50:                     .expect( 'Content-Type', /application\/javascript/ )
78:                     .expect( 'Content-Type', /application\/javascript/ )
87:                     .expect( 'Content-Type', /application\/javascript/ )
100:                    .expect( 'Content-Type', /application\/javascript/ )
112:                    .expect( 'Content-Type', /application\/javascript/ )
```

It's because the `/get` routes pass through whatever mime type is sent in the header, and CDNJS still returns `application/javascript`.