### PR TITLE
@swc/core: Upgrade 1.13.1 -> 1.15.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "minifiers",
 			"version": "8.2.1",
 			"dependencies": {
-				"@swc/core": "^1.13.1",
+				"@swc/core": "^1.15.11",
 				"cssnano": "^7.1.0",
 				"cssnano-preset-lite": "^4.0.4",
 				"csso": "^5.0.5",
@@ -1173,14 +1173,14 @@
 			}
 		},
 		"node_modules/@swc/core": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.1.tgz",
-			"integrity": "sha512-jEKKErLC6uwSqA+p6bmZR08usZM5Fpc+HdEu5CAzvye0q43yf1si1kjhHEa9XMkz0A2SAaal3eKCg/YYmtOsCA==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
+			"integrity": "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3",
-				"@swc/types": "^0.1.23"
+				"@swc/types": "^0.1.25"
 			},
 			"engines": {
 				"node": ">=10"
@@ -1190,16 +1190,16 @@
 				"url": "https://opencollective.com/swc"
 			},
 			"optionalDependencies": {
-				"@swc/core-darwin-arm64": "1.13.1",
-				"@swc/core-darwin-x64": "1.13.1",
-				"@swc/core-linux-arm-gnueabihf": "1.13.1",
-				"@swc/core-linux-arm64-gnu": "1.13.1",
-				"@swc/core-linux-arm64-musl": "1.13.1",
-				"@swc/core-linux-x64-gnu": "1.13.1",
-				"@swc/core-linux-x64-musl": "1.13.1",
-				"@swc/core-win32-arm64-msvc": "1.13.1",
-				"@swc/core-win32-ia32-msvc": "1.13.1",
-				"@swc/core-win32-x64-msvc": "1.13.1"
+				"@swc/core-darwin-arm64": "1.15.11",
+				"@swc/core-darwin-x64": "1.15.11",
+				"@swc/core-linux-arm-gnueabihf": "1.15.11",
+				"@swc/core-linux-arm64-gnu": "1.15.11",
+				"@swc/core-linux-arm64-musl": "1.15.11",
+				"@swc/core-linux-x64-gnu": "1.15.11",
+				"@swc/core-linux-x64-musl": "1.15.11",
+				"@swc/core-win32-arm64-msvc": "1.15.11",
+				"@swc/core-win32-ia32-msvc": "1.15.11",
+				"@swc/core-win32-x64-msvc": "1.15.11"
 			},
 			"peerDependencies": {
 				"@swc/helpers": ">=0.5.17"
@@ -1211,9 +1211,9 @@
 			}
 		},
 		"node_modules/@swc/core-darwin-arm64": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.13.1.tgz",
-			"integrity": "sha512-zO6SW/jSMTUORPm6dUZFPUwf+EFWZsaXWMGXadRG6akCofYpoQb8pcY2QZkVr43z8TMka6BtXpyoD/DJ0iOPHQ==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.11.tgz",
+			"integrity": "sha512-QoIupRWVH8AF1TgxYyeA5nS18dtqMuxNwchjBIwJo3RdwLEFiJq6onOx9JAxHtuPwUkIVuU2Xbp+jCJ7Vzmgtg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1227,9 +1227,9 @@
 			}
 		},
 		"node_modules/@swc/core-darwin-x64": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.1.tgz",
-			"integrity": "sha512-8RjaTZYxrlYKE5PgzZYWSOT4mAsyhIuh30Nu4dnn/2r0Ef68iNCbvX4ynGnFMhOIhqunjQbJf+mJKpwTwdHXhw==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.11.tgz",
+			"integrity": "sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==",
 			"cpu": [
 				"x64"
 			],
@@ -1243,9 +1243,9 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm-gnueabihf": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.1.tgz",
-			"integrity": "sha512-jEqK6pECs2m4BpL2JA/4CCkq04p6iFOEtVNXTisO+lJ3zwmxlnIEm9UfJZG6VSu8GS9MHRKGB0ieZ1tEdN1qDA==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.11.tgz",
+			"integrity": "sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==",
 			"cpu": [
 				"arm"
 			],
@@ -1259,9 +1259,9 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm64-gnu": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.1.tgz",
-			"integrity": "sha512-PbkuIOYXO/gQbWQ7NnYIwm59ygNqmUcF8LBeoKvxhx1VtOwE+9KiTfoplOikkPLhMiTzKsd8qentTslbITIg+Q==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.11.tgz",
+			"integrity": "sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1275,9 +1275,9 @@
 			}
 		},
 		"node_modules/@swc/core-linux-arm64-musl": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.1.tgz",
-			"integrity": "sha512-JaqFdBCarIBKiMu5bbAp+kWPMNGg97ej+7KzbKOzWP5pRptqKi86kCDZT3WmjPe8hNG6dvBwbm7Y8JNry5LebQ==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.11.tgz",
+			"integrity": "sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1291,9 +1291,9 @@
 			}
 		},
 		"node_modules/@swc/core-linux-x64-gnu": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.1.tgz",
-			"integrity": "sha512-t4cLkku10YECDaakWUH0452WJHIZtrLPRwezt6BdoMntVMwNjvXRX7C8bGuYcKC3YxRW7enZKFpozLhQIQ37oA==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.11.tgz",
+			"integrity": "sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1307,9 +1307,9 @@
 			}
 		},
 		"node_modules/@swc/core-linux-x64-musl": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.1.tgz",
-			"integrity": "sha512-fSMwZOaG+3ukUucbEbzz9GhzGhUhXoCPqHe9qW0/Vc2IZRp538xalygKyZynYweH5d9EHux1aj3+IO8/xBaoiA==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.11.tgz",
+			"integrity": "sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==",
 			"cpu": [
 				"x64"
 			],
@@ -1323,9 +1323,9 @@
 			}
 		},
 		"node_modules/@swc/core-win32-arm64-msvc": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.1.tgz",
-			"integrity": "sha512-tweCXK/79vAwj1NhAsYgICy8T1z2QEairmN2BFEBYFBFNMEB1iI1YlXwBkBtuihRvgZrTh1ORusKa4jLYzLCZA==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.11.tgz",
+			"integrity": "sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1339,9 +1339,9 @@
 			}
 		},
 		"node_modules/@swc/core-win32-ia32-msvc": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.1.tgz",
-			"integrity": "sha512-zi7hO9D+2R2yQN9D7T10/CAI9KhuXkNkz8tcJOW6+dVPtAk/gsIC5NoGPELjgrAlLL9CS38ZQpLDslLfpP15ng==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.11.tgz",
+			"integrity": "sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==",
 			"cpu": [
 				"ia32"
 			],
@@ -1355,9 +1355,9 @@
 			}
 		},
 		"node_modules/@swc/core-win32-x64-msvc": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.1.tgz",
-			"integrity": "sha512-KubYjzqs/nz3H69ncX/XHKsC8c1xqc7UvonQAj26BhbL22HBsqdAaVutZ+Obho6RMpd3F5qQ95ldavUTWskRrw==",
+			"version": "1.15.11",
+			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.11.tgz",
+			"integrity": "sha512-IQ2n6af7XKLL6P1gIeZACskSxK8jWtoKpJWLZmdXTDj1MGzktUy4i+FvpdtxFmJWNavRWH1VmTr6kAubRDHeKw==",
 			"cpu": [
 				"x64"
 			],
@@ -1377,9 +1377,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@swc/types": {
-			"version": "0.1.23",
-			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.23.tgz",
-			"integrity": "sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==",
+			"version": "0.1.25",
+			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+			"integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@swc/counter": "^0.1.3"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"node": ">=16.19.0"
 	},
 	"dependencies": {
-		"@swc/core": "^1.13.1",
+		"@swc/core": "^1.15.11",
 		"cssnano": "^7.1.0",
 		"cssnano-preset-lite": "^4.0.4",
 		"csso": "^5.0.5",


### PR DESCRIPTION
## Summary
- Update @swc/core from 1.13.1 to 1.15.11 (two minor versions)
- Picks up minifier correctness fixes for mangling edge cases, codegen improvements, and significant performance optimizations to the
parser, minifier, and bindings
- No breaking API changes - our usage is limited to `minifySync()` with `mangle: true` / `compress: false`

## Test plan
- [x] Existing test suite passes
