### PR TITLE
Update fastify 5.4.0 -> 5.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"cssnano": "^7.1.0",
 				"cssnano-preset-lite": "^4.0.4",
 				"csso": "^5.0.5",
-				"fastify": "^5.4.0",
+				"fastify": "^5.7.4",
 				"generic-pool": "^3.9.0",
 				"html-minifier-terser": "^7.2.0",
 				"jsonminify": "^0.4.2",
@@ -582,9 +582,9 @@
 			}
 		},
 		"node_modules/@fastify/ajv-compiler": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.2.tgz",
-			"integrity": "sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+			"integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
 			"funding": [
 				{
 					"type": "github",
@@ -1117,6 +1117,12 @@
 			"dependencies": {
 				"@noble/hashes": "^1.1.5"
 			}
+		},
+		"node_modules/@pinojs/redact": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+			"integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+			"license": "MIT"
 		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
@@ -1783,17 +1789,6 @@
 				"win32"
 			]
 		},
-		"node_modules/abort-controller": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dependencies": {
-				"event-target-shim": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=6.5"
-			}
-		},
 		"node_modules/abstract-logging": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -1929,6 +1924,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
 			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -2049,25 +2045,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2136,29 +2113,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"node-int64": "^0.4.0"
-			}
-		},
-		"node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/buffer-from": {
@@ -2971,22 +2925,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/event-target-shim": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/events": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-			"engines": {
-				"node": ">=0.8.x"
-			}
-		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3095,14 +3033,6 @@
 				"fast-decode-uri-component": "^1.0.1"
 			}
 		},
-		"node_modules/fast-redact": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-			"integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/fast-safe-stringify": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -3115,9 +3045,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastify": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.4.0.tgz",
-			"integrity": "sha512-I4dVlUe+WNQAhKSyv15w+dwUh2EPiEl4X2lGYMmNSgF83WzTMAPKGdWEv5tPsCQOb+SOZwz8Vlta2vF+OeDgRw==",
+			"version": "5.7.4",
+			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.7.4.tgz",
+			"integrity": "sha512-e6l5NsRdaEP8rdD8VR0ErJASeyaRbzXYpmkrpr2SuvuMq6Si3lvsaVy5C+7gLanEkvjpMDzBXWE5HPeb/hgTxA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3130,7 +3060,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@fastify/ajv-compiler": "^4.0.0",
+				"@fastify/ajv-compiler": "^4.0.5",
 				"@fastify/error": "^4.0.0",
 				"@fastify/fast-json-stringify-compiler": "^5.0.0",
 				"@fastify/proxy-addr": "^5.0.0",
@@ -3139,29 +3069,13 @@
 				"fast-json-stringify": "^6.0.0",
 				"find-my-way": "^9.0.0",
 				"light-my-request": "^6.0.0",
-				"pino": "^9.0.0",
+				"pino": "^10.1.0",
 				"process-warning": "^5.0.0",
 				"rfdc": "^1.3.1",
 				"secure-json-parse": "^4.0.0",
 				"semver": "^7.6.0",
 				"toad-cache": "^3.7.0"
 			}
-		},
-		"node_modules/fastify/node_modules/process-warning": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-			"integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/fastq": {
 			"version": "1.18.0",
@@ -3540,25 +3454,6 @@
 			"engines": {
 				"node": ">=10.17.0"
 			}
-		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
 		},
 		"node_modules/import-local": {
 			"version": "3.2.0",
@@ -4799,6 +4694,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
 			"integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -5002,39 +4898,41 @@
 			}
 		},
 		"node_modules/pino": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-9.2.0.tgz",
-			"integrity": "sha512-g3/hpwfujK5a4oVbaefoJxezLzsDgLcNJeITvC6yrfwYeT9la+edCK42j5QpEQSQCZgTKapXvnQIdgZwvRaZug==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-10.3.0.tgz",
+			"integrity": "sha512-0GNPNzHXBKw6U/InGe79A3Crzyk9bcSyObF9/Gfo9DLEf5qj5RF50RSjsu0W1rZ6ZqRGdzDFCRBQvi9/rSGPtA==",
+			"license": "MIT",
 			"dependencies": {
+				"@pinojs/redact": "^0.4.0",
 				"atomic-sleep": "^1.0.0",
-				"fast-redact": "^3.1.1",
 				"on-exit-leak-free": "^2.1.0",
-				"pino-abstract-transport": "^1.2.0",
+				"pino-abstract-transport": "^3.0.0",
 				"pino-std-serializers": "^7.0.0",
-				"process-warning": "^3.0.0",
+				"process-warning": "^5.0.0",
 				"quick-format-unescaped": "^4.0.3",
 				"real-require": "^0.2.0",
 				"safe-stable-stringify": "^2.3.1",
 				"sonic-boom": "^4.0.1",
-				"thread-stream": "^3.0.0"
+				"thread-stream": "^4.0.0"
 			},
 			"bin": {
 				"pino": "bin.js"
 			}
 		},
 		"node_modules/pino-abstract-transport": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-			"integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+			"integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+			"license": "MIT",
 			"dependencies": {
-				"readable-stream": "^4.0.0",
 				"split2": "^4.0.0"
 			}
 		},
 		"node_modules/pino-std-serializers": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-			"integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+			"license": "MIT"
 		},
 		"node_modules/pirates": {
 			"version": "4.0.7",
@@ -5614,18 +5512,21 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/process": {
-			"version": "0.11.10",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-			"engines": {
-				"node": ">= 0.6.0"
-			}
-		},
 		"node_modules/process-warning": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-			"integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+			"integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/pure-rand": {
 			"version": "7.0.1",
@@ -5662,7 +5563,8 @@
 		"node_modules/quick-format-unescaped": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+			"license": "MIT"
 		},
 		"node_modules/react-is": {
 			"version": "18.3.1",
@@ -5671,25 +5573,11 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/readable-stream": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-			"integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-			"dependencies": {
-				"abort-controller": "^3.0.0",
-				"buffer": "^6.0.3",
-				"events": "^3.3.0",
-				"process": "^0.11.10",
-				"string_decoder": "^1.3.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
 		"node_modules/real-require": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
 			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 12.13.0"
 			}
@@ -5770,25 +5658,6 @@
 			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
 			"license": "MIT"
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
 		"node_modules/safe-regex2": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-4.0.1.tgz",
@@ -5809,9 +5678,10 @@
 			}
 		},
 		"node_modules/safe-stable-stringify": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-			"integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -5975,9 +5845,10 @@
 			}
 		},
 		"node_modules/sonic-boom": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.0.1.tgz",
-			"integrity": "sha512-hTSD/6JMLyT4r9zeof6UtuBDpjJ9sO08/nmS5djaA9eozT9oOlNdpXSnzcgj4FTqpk3nkLrs61l4gip9r1HCrQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+			"integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+			"license": "MIT",
 			"dependencies": {
 				"atomic-sleep": "^1.0.0"
 			}
@@ -6014,6 +5885,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
 			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+			"license": "ISC",
 			"engines": {
 				"node": ">= 10.x"
 			}
@@ -6036,14 +5908,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/string-length": {
@@ -6448,11 +6312,15 @@
 			}
 		},
 		"node_modules/thread-stream": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-			"integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+			"integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+			"license": "MIT",
 			"dependencies": {
 				"real-require": "^0.2.0"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"cssnano": "^7.1.0",
 		"cssnano-preset-lite": "^4.0.4",
 		"csso": "^5.0.5",
-		"fastify": "^5.4.0",
+		"fastify": "^5.7.4",
 		"generic-pool": "^3.9.0",
 		"html-minifier-terser": "^7.2.0",
 		"jsonminify": "^0.4.2",


### PR DESCRIPTION
## Summary
- Update fastify from 5.4.0 to 5.7.4
- Picks up security fix CVE-2026-25224 (v5.7.3)
- Includes stricter content-type header parsing per RFC 9110 (v5.7.2) — no impact on our usage since we don't register custom content-type parsers or accept POST bodies

## Test plan
- [x] Existing test suite passes
