### PR TITLE
Fastify: Fix FSTDEP022 deprecation: move maxParamLength to routerOptions

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,9 @@ maybeEnableMemoryDebugger();
 
 const server = require( 'fastify' )( {
 	logger: envBool( 'DEBUG_QUIET_REQUEST' ) ? false : true,
-	maxParamLength: 50000, // this defaults to 100, which is way too small
+	routerOptions: {
+		maxParamLength: 50000, // this defaults to 100, which is way too small
+	},
 } );
 if ( envBool( 'DEBUG_QUIET_REQUEST' ) ) {
 	console.debug( 'Quiet mode enabled.' );


### PR DESCRIPTION
## Summary
- Move `maxParamLength` from top-level Fastify options to `routerOptions`, fixing the FSTDEP022 deprecation warning
- This option will be removed from the top level in Fastify 6

## Test plan
- [x] Existing test suite passes
- [x] FSTDEP022 warning no longer emitted
